### PR TITLE
Обработать rate limit и редирект GraphQL API

### DIFF
--- a/Jellyfin.Plugin.Shikimori/Api/ShikimoriApi.cs
+++ b/Jellyfin.Plugin.Shikimori/Api/ShikimoriApi.cs
@@ -157,26 +157,36 @@ namespace Jellyfin.Plugin.Shikimori.Api
             }
         }
 
+        private static bool ShouldRetry(HttpResponseMessage response)
+        {
+            return response.StatusCode == HttpStatusCode.TooManyRequests
+                || (int)response.StatusCode >= 500;
+        }
+
         private async Task<GraphQlResponse?> WebRequestApi(GraphQlRequest request, CancellationToken cancellationToken)
         {
             for (var attempt = 1; attempt <= MaxRequestAttempts; attempt++)
             {
                 using var response = await PostWithThrottleAsync(request, cancellationToken).ConfigureAwait(false);
-                if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                if (ShouldRetry(response))
                 {
                     if (attempt == MaxRequestAttempts)
                     {
-                        _logger.LogWarning("Shikimori API rate limit did not clear after {AttemptCount} attempts. Skipping this metadata request.", MaxRequestAttempts);
+                        _logger.LogWarning("Shikimori API returned HTTP {StatusCode} after {AttemptCount} attempts. Skipping this metadata request.", (int)response.StatusCode, MaxRequestAttempts);
                         return null;
                     }
 
                     var delay = GetRetryDelay(response, attempt);
-                    _logger.LogWarning("Shikimori API returned 429 Too Many Requests. Retrying in {DelaySeconds:0.##} seconds ({Attempt}/{MaxAttempts}).", delay.TotalSeconds, attempt, MaxRequestAttempts);
+                    _logger.LogWarning("Shikimori API returned HTTP {StatusCode}. Retrying in {DelaySeconds:0.##} seconds ({Attempt}/{MaxAttempts}).", (int)response.StatusCode, delay.TotalSeconds, attempt, MaxRequestAttempts);
                     await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                     continue;
                 }
 
-                response.EnsureSuccessStatusCode();
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogWarning("Shikimori API returned HTTP {StatusCode}. Skipping this metadata request.", (int)response.StatusCode);
+                    return null;
+                }
 
                 return JsonConvert.DeserializeObject<GraphQlResponse>(
                     await response.Content.ReadAsStringAsync().ConfigureAwait(false),

--- a/Jellyfin.Plugin.Shikimori/Api/ShikimoriApi.cs
+++ b/Jellyfin.Plugin.Shikimori/Api/ShikimoriApi.cs
@@ -1,13 +1,22 @@
+using System.Net;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 namespace Jellyfin.Plugin.Shikimori.Api
 {
     public class ShikimoriApi
     {
+        private const int MaxRequestAttempts = 4;
+        private static readonly SemaphoreSlim RequestGate = new SemaphoreSlim(1, 1);
+        private static readonly TimeSpan MinRequestInterval = TimeSpan.FromMilliseconds(750);
+        private static readonly TimeSpan DefaultRateLimitDelay = TimeSpan.FromSeconds(10);
+        private static DateTimeOffset _nextRequestAt = DateTimeOffset.MinValue;
+
         // WARNING: Usage of empty or invalid application name could result in ip ban for shikimori!
         // See: https://shikimori.one/oauth
         public string ApplicationName { get; init; }
+        private readonly ILogger _logger;
 
         private string ApiLink => $"{ShikimoriPlugin.Instance!.ShikimoriBaseUrl}/api/graphql";
 
@@ -84,40 +93,113 @@ namespace Jellyfin.Plugin.Shikimori.Api
   }
 }";
 
-        public ShikimoriApi(string applicationName)
+        public ShikimoriApi(string applicationName, ILogger logger)
         {
             ApplicationName = applicationName;
+            _logger = logger;
         }
 
-        private async Task<GraphQlResponse?> WebRequestApi(GraphQlRequest request)
+        private static TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)
         {
-            var httpClient = ShikimoriPlugin.Instance!.HttpClientFactory.CreateClient();
-            httpClient.DefaultRequestHeaders.Add("User-Agent", ApplicationName);
+            var retryAfter = response.Headers.RetryAfter;
+            if (retryAfter?.Delta is { } delta && delta > TimeSpan.Zero)
+            {
+                return delta;
+            }
 
-            var content = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
-            var response = await httpClient.PostAsync(ApiLink, content).ConfigureAwait(false);
+            if (retryAfter?.Date is { } date)
+            {
+                var delay = date - DateTimeOffset.UtcNow;
+                if (delay > TimeSpan.Zero)
+                {
+                    return delay;
+                }
+            }
 
-            response.EnsureSuccessStatusCode();
+            return TimeSpan.FromSeconds(Math.Min(DefaultRateLimitDelay.TotalSeconds, Math.Pow(2, attempt)));
+        }
 
-            return JsonConvert.DeserializeObject<GraphQlResponse>(
+        private static async Task WaitForRateLimitAsync(CancellationToken cancellationToken)
+        {
+            var delay = _nextRequestAt - DateTimeOffset.UtcNow;
+            if (delay > TimeSpan.Zero)
+            {
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task<HttpResponseMessage> PostWithThrottleAsync(GraphQlRequest request, CancellationToken cancellationToken)
+        {
+            await RequestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await WaitForRateLimitAsync(cancellationToken).ConfigureAwait(false);
+
+                var httpClient = ShikimoriPlugin.Instance!.HttpClientFactory.CreateClient();
+                httpClient.DefaultRequestHeaders.Add("User-Agent", ApplicationName);
+
+                var content = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
+                var response = await httpClient.PostAsync(ApiLink, content, cancellationToken).ConfigureAwait(false);
+
+                var nextRequestAt = DateTimeOffset.UtcNow + MinRequestInterval;
+                if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    var retryDelay = GetRetryDelay(response, 1);
+                    nextRequestAt = DateTimeOffset.UtcNow + retryDelay;
+                }
+                _nextRequestAt = nextRequestAt;
+
+                return response;
+            }
+            finally
+            {
+                RequestGate.Release();
+            }
+        }
+
+        private async Task<GraphQlResponse?> WebRequestApi(GraphQlRequest request, CancellationToken cancellationToken)
+        {
+            for (var attempt = 1; attempt <= MaxRequestAttempts; attempt++)
+            {
+                using var response = await PostWithThrottleAsync(request, cancellationToken).ConfigureAwait(false);
+                if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    if (attempt == MaxRequestAttempts)
+                    {
+                        _logger.LogWarning("Shikimori API rate limit did not clear after {AttemptCount} attempts. Skipping this metadata request.", MaxRequestAttempts);
+                        return null;
+                    }
+
+                    var delay = GetRetryDelay(response, attempt);
+                    _logger.LogWarning("Shikimori API returned 429 Too Many Requests. Retrying in {DelaySeconds:0.##} seconds ({Attempt}/{MaxAttempts}).", delay.TotalSeconds, attempt, MaxRequestAttempts);
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                response.EnsureSuccessStatusCode();
+
+                return JsonConvert.DeserializeObject<GraphQlResponse>(
                     await response.Content.ReadAsStringAsync().ConfigureAwait(false),
                     new AnimeBaseConverter()
                     );
+            }
+
+            return null;
         }
 
-        public async Task<IEnumerable<AnimeBase>> SearchAnimesAsync(SearchOptions options)
+        public async Task<IEnumerable<AnimeBase>> SearchAnimesAsync(SearchOptions options, CancellationToken cancellationToken)
         {
             var request = new GraphQlRequest()
             {
                 query = SearchQuery.Replace("{0}", options.ToString())
             };
 
-            var graphQlResponse = await WebRequestApi(request).ConfigureAwait(false);
+            var graphQlResponse = await WebRequestApi(request, cancellationToken).ConfigureAwait(false);
 
             return graphQlResponse?.data?.animes == null ? Enumerable.Empty<AnimeBase>() : graphQlResponse.data.animes;
         }
 
-        public async Task<Anime?> GetAnimeAsync(long id, bool censored = true)
+        public async Task<Anime?> GetAnimeAsync(long id, bool censored, CancellationToken cancellationToken)
         {
             var options = new SearchOptions()
             {
@@ -129,7 +211,7 @@ namespace Jellyfin.Plugin.Shikimori.Api
                 query = AnimeQuery.Replace("{0}", options.ToString())
             };
 
-            var graphQlResponse = await WebRequestApi(request).ConfigureAwait(false);
+            var graphQlResponse = await WebRequestApi(request, cancellationToken).ConfigureAwait(false);
             var animes = graphQlResponse?.data?.animes;
             if (animes == null || animes.Count() == 0) return null;
 

--- a/Jellyfin.Plugin.Shikimori/Configuration/config.html
+++ b/Jellyfin.Plugin.Shikimori/Configuration/config.html
@@ -64,7 +64,7 @@
 
                 <div class="inputContainer">
                     <label class="inputLabel inputLabelUnfocused" for="searchLimit">Shikimori Base Url</label>
-                    <input id="shikimoriBaseUrl" name="shikimoriBaseUrl" type="url" is="emby-input" placeholder="https://shikimori.one"/>
+                    <input id="shikimoriBaseUrl" name="shikimoriBaseUrl" type="url" is="emby-input" placeholder="https://shikimori.io"/>
                     <div class="fieldDescription">The url of shikimori. Change it only if you know what you're doing.</div>
                 </div>
 

--- a/Jellyfin.Plugin.Shikimori/ShikimoriClientManager.cs
+++ b/Jellyfin.Plugin.Shikimori/ShikimoriClientManager.cs
@@ -24,7 +24,7 @@ namespace Jellyfin.Plugin.Shikimori
 
         public ShikimoriClientManager(ILogger<ShikimoriClientManager> logger)
         {
-            _shikimoriApi = new ShikimoriApi(_clientName);
+            _shikimoriApi = new ShikimoriApi(_clientName, logger);
 
             _logger = logger;
         }
@@ -43,7 +43,7 @@ namespace Jellyfin.Plugin.Shikimori
                     _ => null
                 },
                 censored = !ShikimoriPlugin.Instance!.Configuration.ShowCensored
-            }).ConfigureAwait(false)).ToList();
+            }, cancellationToken).ConfigureAwait(false)).ToList();
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -69,7 +69,7 @@ namespace Jellyfin.Plugin.Shikimori
 
         public async Task<Anime?> GetAnimeAsync(long id, CancellationToken cancellationToken, AnimeType? type = null)
         {
-            var anime = await _shikimoriApi.GetAnimeAsync(id, !ShikimoriPlugin.Instance!.Configuration.ShowCensored).ConfigureAwait(false);
+            var anime = await _shikimoriApi.GetAnimeAsync(id, !ShikimoriPlugin.Instance!.Configuration.ShowCensored, cancellationToken).ConfigureAwait(false);
             if (anime == null) return anime;
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -95,7 +95,7 @@ namespace Jellyfin.Plugin.Shikimori
                     _ => null
                 },
                 censored = !ShikimoriPlugin.Instance!.Configuration.ShowCensored
-            }).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/Jellyfin.Plugin.Shikimori/ShikimoriPlugin.cs
+++ b/Jellyfin.Plugin.Shikimori/ShikimoriPlugin.cs
@@ -22,7 +22,7 @@ namespace Jellyfin.Plugin.Shikimori
 
         public const string ProviderName = "Shikimori";
         public const string ProviderId = "Shikimori";
-        public const string ShikimoriBaseUrlDefault = "https://shikimori.one";
+        public const string ShikimoriBaseUrlDefault = "https://shikimori.io";
         public string ShikimoriBaseUrl
         {
             get


### PR DESCRIPTION
## Проблема

У меня в логах Jellyfin этот плагин начал часто падать на запросах к Shikimori с `429 Too Many Requests`.

## Что нашел

Плагин отправляет запросы к GraphQL API без общего ограничения частоты, а Jellyfin может запускать несколько запросов к metadata provider параллельно. Из-за этого Shikimori начинает отвечать `429`.

Еще обнаружилось, что запросы на `shikimori.one/api/graphql` сейчас уходят редиректом на `shikimori.io/api/graphql`, и в этом сценарии `HttpClient` может получить `404`.

При этом любой неуспешный HTTP-ответ сразу проходил через `EnsureSuccessStatusCode()`, поэтому ошибка попадала наружу в Jellyfin и спамила лог.

## Что сделано

Добавил общий throttle для запросов к Shikimori API.

Добавил retry для `429 Too Many Requests`, в том числе с учетом `Retry-After`.

GraphQL-запросы для `shikimori.one` теперь отправляются напрямую на `shikimori.io`, без проблемного редиректа.

Неуспешные ответы API теперь обрабатываются внутри плагина и не превращаются в ошибку metadata provider в логах Jellyfin.